### PR TITLE
feat: Implement Clerk authentication login wall

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,8 +42,8 @@ export default function RootLayout({
               <Navigation />
               <div className="flex items-center gap-4">
                 <SignedOut>
-                  <SignInButton signInUrl="/sign-in" />
-                  <SignUpButton signUpUrl="/sign-up" />
+                  <SignInButton />
+                  <SignUpButton />
                 </SignedOut>
                 <SignedIn>
                   <UserButton />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,8 +42,8 @@ export default function RootLayout({
               <Navigation />
               <div className="flex items-center gap-4">
                 <SignedOut>
-                  <SignInButton />
-                  <SignUpButton />
+                  <SignInButton signInUrl="/sign-in" />
+                  <SignUpButton signUpUrl="/sign-up" />
                 </SignedOut>
                 <SignedIn>
                   <UserButton />

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function Page() {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+      <SignIn path="/sign-in" />
+    </div>
+  );
+}

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignUp } from "@clerk/nextjs";
+
+export default function Page() {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+      <SignUp path="/sign-up" />
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,13 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { authMiddleware } from "@clerk/nextjs/server";
 
-export default clerkMiddleware();
+export default authMiddleware({
+  // Ensure that this route is public
+  publicRoutes: ['/'],
+  // Redirect unauthenticated users to the sign-in page
+  // Make sure to create this page in a later step
+  signInUrl: '/sign-in',
+});
 
 export const config = {
-  matcher: [
-    // Skip Next.js internals and all static files, unless found in search params
-    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
-    // Always run for API routes
-    "/(api|trpc)(.*)",
-  ],
+  matcher: ['/((?!.*\..*|_next).*)', '/', '/(api|trpc)(.*)'],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,9 @@
-import { authMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware } from "@clerk/nextjs";
 
-export default authMiddleware({
-  // Ensure that this route is public
+export default clerkMiddleware({
   publicRoutes: ['/'],
-  // Redirect unauthenticated users to the sign-in page
-  // Make sure to create this page in a later step
   signInUrl: '/sign-in',
+  signUpUrl: '/sign-up', // Added this line
 });
 
 export const config = {


### PR DESCRIPTION
This commit introduces a login wall using Clerk for the Next.js application.

Key changes include:
- Configured Clerk middleware (`src/middleware.ts`) to protect all routes by default, redirecting unauthenticated users to a sign-in page. The home page ('/') is public.
- Created dedicated sign-in (`src/app/sign-in/[[...sign-in]]/page.tsx`) and sign-up (`src/app/sign-up/[[...sign-up]]/page.tsx`) pages using Clerk's `<SignIn />` and `<SignUp />` components.
- Updated `src/app/layout.tsx` to ensure `SignInButton` and `SignUpButton` correctly link to the new dedicated sign-in and sign-up pages.

The application now requires you to authenticate before accessing protected routes, enhancing security and user management capabilities.