### PR TITLE
Require sign in via Clerk

### DIFF
--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,5 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function SignInPage() {
+  return <SignIn />;
+}

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,5 @@
+import { SignUp } from "@clerk/nextjs";
+
+export default function SignUpPage() {
+  return <SignUp />;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,8 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { authMiddleware } from "@clerk/nextjs";
 
-export default clerkMiddleware();
+export default authMiddleware({
+  publicRoutes: ["/sign-in(.*)", "/sign-up(.*)"],
+});
 
 export const config = {
   matcher: [

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 
 export default authMiddleware({
   publicRoutes: ["/sign-in(.*)", "/sign-up(.*)"],

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,14 +1,26 @@
-import { authMiddleware } from "@clerk/nextjs/server";
+import { getAuth, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 
-export default authMiddleware({
-  publicRoutes: ["/sign-in(.*)", "/sign-up(.*)"],
-});
+const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)"]);
+
+export default function middleware(request: NextRequest) {
+  if (isPublicRoute(request)) {
+    return NextResponse.next();
+  }
+
+  const { userId } = getAuth(request);
+  if (!userId) {
+    const signInUrl = new URL("/sign-in", request.url);
+    signInUrl.searchParams.set("redirect_url", request.url);
+    return NextResponse.redirect(signInUrl);
+  }
+  return NextResponse.next();
+}
 
 export const config = {
   matcher: [
-    // Skip Next.js internals and all static files, unless found in search params
     "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
-    // Always run for API routes
     "/(api|trpc)(.*)",
   ],
 };


### PR DESCRIPTION
## Summary
- protect all routes with Clerk auth middleware
- add dedicated `/sign-in` and `/sign-up` pages using Clerk components

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843af8731908322a5417e8b24c97485